### PR TITLE
remove unused import "sync"

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -71,7 +71,6 @@ import (
 	"net"
 	"os"
 	"strconv"
-	"sync"
 	"syscall"
 	"time"
 


### PR DESCRIPTION
minor patch to allow build by `go get`

line 74 : https://github.com/shadowsocks/kcptun/commit/77b5ed21674bb8444a2629f8490d21310d76e352