### PR TITLE
fix: listen error under ipv6 host

### DIFF
--- a/server/args.go
+++ b/server/args.go
@@ -3,10 +3,16 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"net"
 	"os"
 	"sort"
 	"strings"
 )
+
+func isIPv6(str string) bool {
+	ip := net.ParseIP(str)
+	return ip != nil && strings.Contains(str, ":")
+}
 
 // Key–value mappings for the representation of client and server options.
 
@@ -75,6 +81,12 @@ func parseEnv() (opts Args, err error) {
 	}
 	if len(ss_local_host) == 0 {
 		return
+	}
+	if isIPv6(ss_remote_host) {
+	    ss_remote_host = "[" + ss_remote_host + "]"
+	}
+	if isIPv6(ss_local_host) {
+	    ss_local_host = "[" + ss_local_host + "]"
 	}
 	opts.Add("listen", ss_remote_host+":"+ss_remote_port)
 	opts.Add("target", ss_local_host+":"+ss_local_port)


### PR DESCRIPTION
> error recurrence

```
~/kcptun # ss-libev-server -s ::1 -p 12345 -k dnomd343 -m aes-256-ctr --plugin ./kcptun-server
 2022-03-04 16:50:19 INFO: plugin "./kcptun-server" enabled
 2022-03-04 16:50:19 INFO: initializing ciphers... aes-256-ctr
 2022-03-04 16:50:19 INFO: Stream ciphers are insecure, therefore deprecated, and should be almost always avoided.
 2022-03-04 16:50:19 INFO: tcp server listening at [::1]:60531
 2022-03-04 16:50:19 INFO: running from root user
2022/03/04 16:50:20 main.go:398: version: SELFBUILD
2022/03/04 16:50:20 main.go:111: address ::1:12345: too many colons in address
github.com/xtaci/kcp-go.ListenWithOptions
        /root/go/pkg/mod/github.com/xtaci/kcp-go@v5.4.20+incompatible/sess.go:970
main.main.func1
        /root/kcptun/server/main.go:430
github.com/urfave/cli.HandleAction
        /root/go/pkg/mod/github.com/urfave/cli@v1.22.5/app.go:524
github.com/urfave/cli.(*App).Run
        /root/go/pkg/mod/github.com/urfave/cli@v1.22.5/app.go:286
main.main
        /root/kcptun/server/main.go:484
runtime.main
        /usr/lib/go/src/runtime/proc.go:255
runtime.goexit
        /usr/lib/go/src/runtime/asm_amd64.s:1581
 2022-03-04 16:50:20 ERROR: plugin service exit unexpectedly
 2022-03-04 16:50:20 INFO: error on terminating the plugin.
```